### PR TITLE
KeyPair.getById() can now take an array of ids.

### DIFF
--- a/lib/advanced_structures/KeyPair.js
+++ b/lib/advanced_structures/KeyPair.js
@@ -155,14 +155,17 @@ KeyPair.prototype.get = function (value, callback) {
 /**
  * Get the value associated with the id.
  *
- * @param {int} id
+ * @param {int|Array} id(s)
  * @param {Function} callback
  * @return this
  * @api public
  */
 
 KeyPair.prototype.getById = function (id, callback) {
-    this.client.hget(this.key, id, callback);
+	if (Array.isArray(id))
+    	this.client.hmget(this.key, id, callback);
+	else
+    	this.client.hget(this.key, id, callback);
     return this;
 }
 

--- a/test/keypair.test.js
+++ b/test/keypair.test.js
@@ -45,6 +45,13 @@ module.exports = {
                     assert.equal('bar', value);
                 });
 
+                keypair.getById([1, 2], function (err, values) {
+                    assert(Array.isArray(values));
+                    assert.equal(values.length, 2);
+                    assert.equal('foo', values.shift());
+                    assert.equal('bar', values.shift());
+                });
+
                 keypair.get('nothere', function (err, id) {
                     assert.equal(null, id);
                 });


### PR DESCRIPTION
I needed this feature & thought others might find it handy too. There's a new unit test for it and the method documentation has been tweaked to match.
