### PR TITLE
In the flush() method, if no keys matched the pattern, the callback was ...

### DIFF
--- a/lib/Cache.js
+++ b/lib/Cache.js
@@ -284,7 +284,7 @@ Cache.prototype.flush = function (pattern, callback) {
     var self = this;
     this.keys(pattern, true, function (err, keys) {
         if (err) return callback(err, null);
-        if (!keys) return callback(err, []);
+        if (!keys || keys.length === 0) return callback(err, []);
         var error = false, remaining = keys.length, del_count = 0;
         keys.forEach(function (key) {
             self.client.del(key, function (err, deleted) {


### PR DESCRIPTION
...never being called.
